### PR TITLE
Fix compile error

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -12,6 +12,7 @@ use super::platform::SBPlatform;
 use super::stream::SBStream;
 use super::structureddata::SBStructuredData;
 use super::target::SBTarget;
+use super::commandinterpreter::SBCommandInterpreter;
 use sys;
 
 /// Creates [`SBTarget`]s, provides access to them and manages


### PR DESCRIPTION
```
❯ cargo build
   Compiling lldb-sys v0.0.19
   Compiling lldb v0.0.7 (file:///home/hugh/tmp/lldb.rs)
error[E0433]: failed to resolve. Use of undeclared type or module `SBCommandInterpreter`
   --> src/debugger.rs:181:9
    |
181 |         SBCommandInterpreter::wrap(unsafe { sys::SBDebuggerGetCommandInterpreter(self.raw) })
    |         ^^^^^^^^^^^^^^^^^^^^ Use of undeclared type or module `SBCommandInterpreter`

error[E0412]: cannot find type `SBCommandInterpreter` in this scope
   --> src/debugger.rs:180:42
    |
180 |     pub fn command_interpreter(&self) -> SBCommandInterpreter {
    |                                          ^^^^^^^^^^^^^^^^^^^^ not found in this scope
help: possible candidate is found in another module, you can import it into scope
    |
7   | use commandinterpreter::SBCommandInterpreter;
    |

error: aborting due to 2 previous errors

Some errors occurred: E0412, E0433.
For more information about an error, try `rustc --explain E0412`.
error: Could not compile `lldb`.

To learn more, run the command again with --verbose.
```