### PR TITLE
Fix sigfault on lldb::SBFrame::function_name

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -150,7 +150,7 @@ impl SBFrame {
     /// See also `is_inlined`.
     pub fn function_name(&self) -> Option<&str> {
         unsafe {
-            match CStr::from_ptr(sys::SBFrameGetFunctionName(self.raw)).to_str() {
+            match CStr::from_ptr(sys::SBFrameGetFunctionName(self.raw).as_ref()?).to_str() {
                 Ok(s) => Some(s),
                 _ => None,
             }


### PR DESCRIPTION
(lldb) bt
* thread #1, name = 'crash_analyse', stop reason = signal SIGSEGV: invalid address (fault address: 0x0)
  * frame #0: 0x00007ffff60ec661 libc.so.6`__strlen_avx2 + 17
    frame #1: 0x000055555556b859 crash_analyse`std::ffi::c_str::CStr::from_ptr::h7d6778659191997d at c_str.rs:904
    frame #2: 0x000055555555ed45 crash_analyse`lldb::frame::SBFrame::function_name::h6e8217ef78893c79(self=0x00007fffffffe848) at frame.rs:153