### PR TITLE
update for additional error obejcts

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -154,9 +154,16 @@ impl SBTarget {
     }
 
     #[allow(missing_docs)]
-    pub fn load_core(&self, core_file: &str) -> SBProcess {
+    pub fn load_core(&self, core_file: &str) ->  Result<SBProcess, SBError> {
+        let error: SBError = SBError::new();
         let core_file = CString::new(core_file).unwrap();
-        SBProcess::wrap(unsafe { sys::SBTargetLoadCore(self.raw, core_file.as_ptr()) })
+        let process =
+            SBProcess::wrap(unsafe { sys::SBTargetLoadCore(self.raw, core_file.as_ptr(), error.raw) });
+        if error.is_success() {
+            Ok(process)
+        } else {
+            Err(error)
+        }
     }
 
     #[allow(missing_docs)]

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -7,6 +7,7 @@
 use super::event::SBEvent;
 use super::frame::SBFrame;
 use super::process::SBProcess;
+use super::error::SBError;
 use super::queue::SBQueue;
 use super::stream::SBStream;
 use super::value::SBValue;
@@ -184,14 +185,16 @@ impl SBThread {
     /// `run_to_address`), the thread will not be allowed to run and these
     /// functions will simply return.
     pub fn suspend(&self) -> u8 {
-        unsafe { sys::SBThreadSuspend(self.raw) }
+        let error: SBError = SBError::new();
+        unsafe { sys::SBThreadSuspend(self.raw, error.raw) }
     }
 
     /// Set the user resume state for this to allow it to run again.
     ///
     /// See the discussion on `suspend` for further details.
     pub fn resume(&self) -> u8 {
-        unsafe { sys::SBThreadResume(self.raw) }
+        let error: SBError = SBError::new();
+        unsafe { sys::SBThreadResume(self.raw, error.raw) }
     }
 
     /// Is this thread set to the suspended user resume state?


### PR DESCRIPTION
Some of the process and thread bindings in lldb-sys.rs seem to require an additional error object.
This PR updates the calls in lldb.rs to match that.
