### PR TITLE
Control lldb via commands and read stdout

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -231,7 +231,7 @@ impl SBDebugger {
 
         let err_str = unsafe { sys::SBCommandReturnObjectGetError(result) };
         match unsafe { CStr::from_ptr(err_str).to_str() } {
-            Ok(s) => return Err(s.to_string()),
+            Ok(s) => Err(s.to_string()),
             Err(err_str) => Err(err_str.to_string()),
         }
     }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -204,7 +204,7 @@ impl SBDebugger {
     /// contains an error message.
     ///
     /// (lldb) b main
-    /// => Is equal to debugger.execute_command("b main")
+    /// => Is equal to `debugger.execute_command("b main")`
     ///
     pub fn execute_command(&self, command: &str) -> Result<&str, String> {
         let result = unsafe { sys::CreateSBCommandReturnObject() };

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -86,7 +86,7 @@ impl SBListener {
     }
 
     #[allow(missing_docs)]
-    pub fn wait_for_event(&self, num_seconds: u32, event: &mut SBEvent) -> bool {
+    pub fn wait_for_event(&self, num_seconds: u32, event: &SBEvent) -> bool {
         unsafe { sys::SBListenerWaitForEvent(self.raw, num_seconds, event.raw) }
     }
 
@@ -95,7 +95,7 @@ impl SBListener {
         &self,
         num_seconds: u32,
         broadcaster: &SBBroadcaster,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe {
             sys::SBListenerWaitForEventForBroadcaster(
@@ -113,7 +113,7 @@ impl SBListener {
         num_seconds: u32,
         broadcaster: &SBBroadcaster,
         event_type_mask: u32,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe {
             sys::SBListenerWaitForEventForBroadcasterWithType(
@@ -127,7 +127,7 @@ impl SBListener {
     }
 
     #[allow(missing_docs)]
-    pub fn peek_at_next_event(&self, event: &mut SBEvent) -> bool {
+    pub fn peek_at_next_event(&self, event: &SBEvent) -> bool {
         unsafe { sys::SBListenerPeekAtNextEvent(self.raw, event.raw) }
     }
 
@@ -135,7 +135,7 @@ impl SBListener {
     pub fn peek_at_next_event_for_broadcaster(
         &self,
         broadcaster: &SBBroadcaster,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe {
             sys::SBListenerPeekAtNextEventForBroadcaster(self.raw, broadcaster.raw, event.raw)
@@ -147,7 +147,7 @@ impl SBListener {
         &self,
         broadcaster: &SBBroadcaster,
         event_type_mask: u32,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe {
             sys::SBListenerPeekAtNextEventForBroadcasterWithType(
@@ -160,7 +160,7 @@ impl SBListener {
     }
 
     #[allow(missing_docs)]
-    pub fn get_next_event(&self, event: &mut SBEvent) -> bool {
+    pub fn get_next_event(&self, event: &SBEvent) -> bool {
         unsafe { sys::SBListenerGetNextEvent(self.raw, event.raw) }
     }
 
@@ -168,7 +168,7 @@ impl SBListener {
     pub fn get_next_event_for_broadcaster(
         &self,
         broadcaster: &SBBroadcaster,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe { sys::SBListenerGetNextEventForBroadcaster(self.raw, broadcaster.raw, event.raw) }
     }
@@ -178,7 +178,7 @@ impl SBListener {
         &self,
         broadcaster: &SBBroadcaster,
         event_type_mask: u32,
-        event: &mut SBEvent,
+        event: &SBEvent,
     ) -> bool {
         unsafe {
             sys::SBListenerGetNextEventForBroadcasterWithType(

--- a/src/process.rs
+++ b/src/process.rs
@@ -266,6 +266,18 @@ impl SBProcess {
         }
     }
 
+    /// Reads data from the current process's stdout stream.
+    pub fn get_stdout(&self) -> Option<String> {
+        let dst_len = 0x1000;
+        let mut dst: Vec<u8> = Vec::with_capacity(dst_len);
+
+        let out_len =
+            unsafe { sys::SBProcessGetSTDOUT(self.raw, dst.as_mut_ptr() as *mut i8, dst_len) };
+
+        unsafe { dst.set_len(out_len) };
+        String::from_utf8(dst).ok()
+    }
+
     #[allow(missing_docs)]
     pub fn broadcaster(&self) -> SBBroadcaster {
         SBBroadcaster::wrap(unsafe { sys::SBProcessGetBroadcaster(self.raw) })

--- a/src/process.rs
+++ b/src/process.rs
@@ -266,6 +266,24 @@ impl SBProcess {
         }
     }
 
+    /// Reads data from the current process's stdout stream until the end ot the stream.
+    pub fn get_stdout_all(&self) -> Option<String> {
+        let dst_len = 0x1000;
+        let mut output = "".to_string();
+        let mut dst: Vec<u8> = Vec::with_capacity(dst_len);
+        loop {
+            let out_len =
+                unsafe { sys::SBProcessGetSTDOUT(self.raw, dst.as_mut_ptr() as *mut i8, dst_len) };
+            if out_len == 0 {
+                break;
+            }
+            unsafe { dst.set_len(out_len) };
+            output += std::str::from_utf8(&dst).ok()?;
+        }
+
+        Some(output)
+    }
+
     /// Reads data from the current process's stdout stream.
     pub fn get_stdout(&self) -> Option<String> {
         let dst_len = 0x1000;


### PR DESCRIPTION
I added some new functions that I needed for a project of mine to control LLDB via commands with the function `execute_command`. I also added the functions `get_stdout` and `get_stdout_all` to read the stdout from the process. 