### PR TITLE
safely handle nullptr for SBValue (fixes #23)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -316,15 +316,15 @@ impl SBValue {
         self.id() as i32
     }
 
-    fn name() -> &str {
+    fn name() -> Option<&str> {
         self.name()
     }
 
-    fn type_name() -> &str {
+    fn type_name() -> Option<&str> {
         self.type_name()
     }
 
-    fn display_type_name() -> &str {
+    fn display_type_name() -> Option<&str> {
         self.display_type_name()
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use std::ffi::{CStr, CString};
 use std::fmt;
+use std::os::raw::c_char;
 
 /// The value of a variable, register or expression.
 pub struct SBValue {
@@ -53,33 +54,18 @@ impl SBValue {
     }
 
     #[allow(missing_docs)]
-    pub fn name(&self) -> &str {
-        unsafe {
-            match CStr::from_ptr(sys::SBValueGetName(self.raw)).to_str() {
-                Ok(s) => s,
-                _ => panic!("Invalid string?"),
-            }
-        }
+    pub fn name(&self) -> Option<&str> {
+        unsafe { self.check_null_ptr(sys::SBValueGetName(self.raw)) }
     }
 
     #[allow(missing_docs)]
-    pub fn type_name(&self) -> &str {
-        unsafe {
-            match CStr::from_ptr(sys::SBValueGetTypeName(self.raw)).to_str() {
-                Ok(s) => s,
-                _ => panic!("Invalid string?"),
-            }
-        }
+    pub fn type_name(&self) -> Option<&str> {
+        unsafe { self.check_null_ptr(sys::SBValueGetTypeName(self.raw)) }
     }
 
     #[allow(missing_docs)]
-    pub fn display_type_name(&self) -> &str {
-        unsafe {
-            match CStr::from_ptr(sys::SBValueGetDisplayTypeName(self.raw)).to_str() {
-                Ok(s) => s,
-                _ => panic!("Invalid string?"),
-            }
-        }
+    pub fn display_type_name(&self) -> Option<&str> {
+        unsafe { self.check_null_ptr(sys::SBValueGetDisplayTypeName(self.raw)) }
     }
 
     #[allow(missing_docs)]
@@ -103,13 +89,8 @@ impl SBValue {
     }
 
     #[allow(missing_docs)]
-    pub fn value(&self) -> &str {
-        unsafe {
-            match CStr::from_ptr(sys::SBValueGetValue(self.raw)).to_str() {
-                Ok(s) => s,
-                _ => panic!("Invalid string?"),
-            }
-        }
+    pub fn value(&self) -> Option<&str> {
+        unsafe { self.check_null_ptr(sys::SBValueGetValue(self.raw)) }
     }
 
     #[allow(missing_docs)]
@@ -256,6 +237,17 @@ impl SBValue {
     #[allow(missing_docs)]
     pub fn address(&self) -> Option<SBAddress> {
         SBAddress::maybe_wrap(unsafe { sys::SBValueGetAddress(self.raw) })
+    }
+
+    unsafe fn check_null_ptr(&self, ptr: *const c_char) -> Option<&str> {
+        if !ptr.is_null() {
+            match CStr::from_ptr(ptr).to_str() {
+                Ok(s) => Some(s),
+                _ => panic!("Invalid string?"),
+            }
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Based on the work by @tetenpapier in https://github.com/endoli/lldb.rs/pull/24.