### PR TITLE
expose simple step_into() for SBThread()

### DIFF
--- a/src/thread.rs
+++ b/src/thread.rs
@@ -249,7 +249,7 @@ impl SBThread {
     }
 
     #[allow(missing_docs)]
-    pub fn step_into3(
+    pub fn step_into_until(
         &self,
         target_name: Option<&str>,
         end_line: u32,

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -242,15 +242,9 @@ impl SBThread {
     }
 
     #[allow(missing_docs)]
-    pub fn step_into(&self, stop_other_threads: RunMode) -> Result<(), SBError> {
-        let error = SBError::default();
+    pub fn step_into(&self, stop_other_threads: RunMode) {
         unsafe {
             sys::SBThreadStepInto(self.raw, stop_other_threads);
-        }
-        if error.is_success() {
-            Ok(())
-        } else {
-            Err(error)
         }
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -242,7 +242,20 @@ impl SBThread {
     }
 
     #[allow(missing_docs)]
-    pub fn step_into(
+    pub fn step_into(&self, stop_other_threads: RunMode) -> Result<(), SBError> {
+        let error = SBError::default();
+        unsafe {
+            sys::SBThreadStepInto(self.raw, stop_other_threads);
+        }
+        if error.is_success() {
+            Ok(())
+        } else {
+            Err(error)
+        }
+    }
+
+    #[allow(missing_docs)]
+    pub fn step_into3(
         &self,
         target_name: Option<&str>,
         end_line: u32,


### PR DESCRIPTION
This exposes the simple `SBThreadStepInto` with only one parameter as `step_into()` and the existing one as `step_into3` (better name suggestion welcome, maybe `step_into_until()`?).