### PR TITLE
add SBProcess and SBThread broadcaster bit definitions

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -679,6 +679,19 @@ impl<'e> SBProcessEvent<'e> {
             idx: 0,
         }
     }
+
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_STATE_CHANGED: u32 = (1 << 0);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_INTERRUPT: u32 = (1 << 1);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_STDOUT: u32 = (1 << 2);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_STDERR: u32 = (1 << 3);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_PROFILE_DATA: u32 = (1 << 4);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_STRUCTURED_DATA: u32 = (1 << 5);
 }
 
 /// Iterate over the restart reasons in a [process event].

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -401,6 +401,17 @@ impl<'e> SBThreadEvent<'e> {
     pub fn frame(&self) -> Option<SBFrame> {
         SBFrame::maybe_wrap(unsafe { sys::SBThreadGetStackFrameFromEvent(self.event.raw) })
     }
+
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_STACK_CHANGED: u32 = (1 << 0);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_THREAD_SUSPENDED: u32 = (1 << 1);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_THREAD_RESUMED: u32 = (1 << 2);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_SELECTED_FRAME_CHANGED: u32 = (1 << 3);
+    #[allow(missing_docs)]
+    pub const BROADCAST_BIT_THREAD_SELECTED: u32 = (1 << 4);
 }
 
 #[cfg(feature = "graphql")]


### PR DESCRIPTION
Taken from the public lldb API:

* `SBThread`: https://github.com/llvm/llvm-project/blob/60de56c743c414240b293a8b8ee10bc2129d7e10/lldb/include/lldb/API/SBThread.h#L29-L33
* `SBProcess`: https://github.com/llvm/llvm-project/blob/main/lldb/include/lldb/API/SBProcess.h#L32-L37

I need them to make sense of the events.